### PR TITLE
Favicons fix: Use google API instead

### DIFF
--- a/src/Data/favicon.ts
+++ b/src/Data/favicon.ts
@@ -1,5 +1,5 @@
 export const faviconFromUrl = (url: string): string => {
   let domainUrl: URL = new URL(url);
   const domain = domainUrl.hostname.replace('www.', '');
-  return `https://puny-yellow-llama.faviconkit.com/${domain}/256`;
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=256`;
 };

--- a/tests/unit/Components/Bookmark/Items/BookmarkGridItem.test.tsx
+++ b/tests/unit/Components/Bookmark/Items/BookmarkGridItem.test.tsx
@@ -10,7 +10,7 @@ describe('BookmarkGridItem', () => {
     expect(screen.getByText(title)).toBeInTheDocument();
     expect(screen.getByTestId('image-with-fallback')).toHaveAttribute(
       'src',
-      `https://puny-yellow-llama.faviconkit.com/example.com/256`
+      `https://www.google.com/s2/favicons?domain=example.com&sz=256`
     );
   });
 

--- a/tests/unit/Components/Bookmark/Items/BookmarkListItem.test.tsx
+++ b/tests/unit/Components/Bookmark/Items/BookmarkListItem.test.tsx
@@ -10,7 +10,7 @@ describe('BookmarkListItem', () => {
     expect(screen.getByText(title)).toBeInTheDocument();
     expect(screen.getByTestId('image-with-fallback')).toHaveAttribute(
       'src',
-      `https://puny-yellow-llama.faviconkit.com/example.com/256`
+      `https://www.google.com/s2/favicons?domain=example.com&sz=256`
     );
   });
 

--- a/tests/unit/Data/favicon.test.tsx
+++ b/tests/unit/Data/favicon.test.tsx
@@ -3,14 +3,16 @@ import { faviconFromUrl } from '../../../src/Data/favicon';
 describe('faviconFromUrl', () => {
   it('returns a valid URL when given a valid input URL', () => {
     const url = 'https://www.google.com';
-    const expected = 'https://puny-yellow-llama.faviconkit.com/google.com/256';
+    const expected =
+      'https://www.google.com/s2/favicons?domain=google.com&sz=256';
     const actual = faviconFromUrl(url);
     expect(actual).toBe(expected);
   });
 
   it('removes the "www." subdomain from the input URL hostname', () => {
     const url = 'https://www.example.com';
-    const expected = 'https://puny-yellow-llama.faviconkit.com/example.com/256';
+    const expected =
+      'https://www.google.com/s2/favicons?domain=example.com&sz=256';
     const actual = faviconFromUrl(url);
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
 Use google API instead of faviconkit due to ssl certificates not being renewed